### PR TITLE
Added release() and close() methods so the channel can be reopened() …

### DIFF
--- a/GenericChannelHeartRateBarrel.mc
+++ b/GenericChannelHeartRateBarrel.mc
@@ -11,8 +11,9 @@ module GenericChannelHeartRateBarrel {
     const MESSAGE_ID_INDEX = 0;
     const MESSAGE_CODE_INDEX = 1;
     
+    const INVALID_HR = 0;
+    
     class LegacyHeartData {
-        const INVALID_HR = 0;
         
         var computedHeartRate;
         
@@ -26,6 +27,10 @@ module GenericChannelHeartRateBarrel {
         
         static function parse( payload, data ) {
             data.computedHeartRate = payload[COMPUTED_HR_INDEX];
+        }
+        
+        static function reset(data) {
+            data.computedHeartRate = INVALID_HR;
         }
     }
     
@@ -91,6 +96,16 @@ module GenericChannelHeartRateBarrel {
             GenericChannel.open();
         }
         
+        // Closes the generic channel
+        function close() {
+            GenericChannel.close();
+        }
+        
+        // Release the generic channel
+        function release() {
+            GenericChannel.release();
+        }
+        
         // On new ANT Message, parses the message
         // @param msg, a Toybox.Ant.Message object
         function onMessage( msg ) {
@@ -119,6 +134,10 @@ module GenericChannelHeartRateBarrel {
                             break;
                     }
                 }
+                
+                // TODO - this is not in the right place.
+                LegacyHeartRateMessage.reset(data);
+                
             } else if ( Toybox.Ant.MSG_ID_BROADCAST_DATA == msg.messageId ) {
                 if ( searching ) {
                     searching = false;  // ANT channel is now tracking

--- a/GenericChannelHeartRateBarrel.mc
+++ b/GenericChannelHeartRateBarrel.mc
@@ -62,10 +62,10 @@ module GenericChannelHeartRateBarrel {
             }
             
             if ( isProximityPairing ) {
-               searchThreshold = CLOSEST_SEARCH_BIN;
+                searchThreshold = CLOSEST_SEARCH_BIN;
             } else { 
-               searchThreshold = WILDCARD_PAIRING;
-           }
+                searchThreshold = WILDCARD_PAIRING;
+            }
             
             searching = true;   // Searching is the default state of an open ANT RX_NOT_TX channel
             


### PR DESCRIPTION
…with a new device index.

@harrychin - can you check the placement of the LegacyHeartRateMessage.reset(data); call? I have a feeling that there are RX events where we do not want this to be called. Also, is releasing the channel and reopening it the best way to reopen the channel with a new device index?